### PR TITLE
Publish new tagged versions of the CLI app into Github Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,20 +1,19 @@
+project_name: dissect-tester-cli
+
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod download
 
 builds:
 - env:
-  - CGO_ENABLED=0
-
-build:
+    - CGO_ENABLED=0
   main: ./cmd/cli/main.go
 
 archives:
 - replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
+    # darwin: Darwin
+    # linux: Linux
+    # windows: Windows
     386: i386
     amd64: x86_64
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+
+builds:
+- env:
+  - CGO_ENABLED=0
+
+build:
+  main: ./cmd/cli/main.go
+
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
We now use Goreleaser to build & publish the CLI app into https://github.com/jorgelbg/dissect-tester/releases.

Docker images are pushed using the old workflow. Will unify on the long run

Closes #3 