### PR TITLE
Show the backend version of the instance

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/processors/dissect"
+	"github.com/elastic/beats/v7/libbeat/version"
 	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -33,7 +34,14 @@ const (
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	tmpl := template.Must(template.ParseFiles("templates/index.html"))
-	if err := tmpl.Execute(w, nil); err != nil {
+
+	data := struct {
+		Version string
+	}{
+		Version: version.GetDefaultVersion(),
+	}
+
+	if err := tmpl.Execute(w, data); err != nil {
 		zap.L().Error("Could not parse template.",
 			zap.String("template", "templates/index.html"),
 			zap.Error(err),
@@ -116,6 +124,8 @@ func main() {
 
 	zap.ReplaceGlobals(logger)
 	defer logger.Sync() // nolint: errcheck
+
+	logger.Info("elastic/beats engine", zap.String("version", version.GetDefaultVersion()))
 
 	_, err = maxprocs.Set(maxprocs.Logger(
 		func(logMessage string, args ...interface{}) {

--- a/main.go
+++ b/main.go
@@ -32,16 +32,16 @@ const (
 	APIPath    = "/api/"
 )
 
+var versionInfo = struct {
+	Version string
+}{
+	Version: version.GetDefaultVersion(),
+}
+
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	tmpl := template.Must(template.ParseFiles("templates/index.html"))
 
-	data := struct {
-		Version string
-	}{
-		Version: version.GetDefaultVersion(),
-	}
-
-	if err := tmpl.Execute(w, data); err != nil {
+	if err := tmpl.Execute(w, versionInfo); err != nil {
 		zap.L().Error("Could not parse template.",
 			zap.String("template", "templates/index.html"),
 			zap.Error(err),
@@ -125,7 +125,7 @@ func main() {
 	zap.ReplaceGlobals(logger)
 	defer logger.Sync() // nolint: errcheck
 
-	logger.Info("elastic/beats engine", zap.String("version", version.GetDefaultVersion()))
+	logger.Info("elastic/beats engine", zap.String("version", versionInfo.Version))
 
 	_, err = maxprocs.Set(maxprocs.Logger(
 		func(logMessage string, args ...interface{}) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,7 +139,7 @@
           This app tries to parse a set of logfile samples with a given dissect
           tokenization pattern and return the matched fields for each log line.
         </p>
-        <h3 class="text-gray-800">
+        <p class="text-gray-800">
           Syntax compatible with
           <a
             class="text-blue-600"
@@ -158,7 +158,16 @@
             >Logstash</a
           >
           processors/filters.
-        </h3>
+        </p>
+      </div>
+      <div class="flex items-center mt-4">
+        <div class="flex items-center justify-center">
+          <svg class="w-8 h-8" viewBox="0 0 64 64"><defs/><g fill="none" fill-rule="evenodd"><path d="M0 0h64v64H0z"/><path fill="#343741" d="M45 28c-2-2-5-3-9-3H11v14h19c7 0 13-5 15-11"/><path fill="#00BFB3" d="M49 31c-3 8-11 13-19 13H11v15h25a17 17 0 0013-28"/><path fill="#07C" d="M45 28A17 17 0 0030 5H11v20h25c4 0 7 1 9 3"/></g></svg>
+          v<span class="text-xl font-medium">{{ .Version }}</span>
+          <div class="ml-2 p-2 text-gray-700">
+            This instance is using a backend running v{{ .Version }} of Elastic Beats.
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
This PR adds the beats version used to generate the current build. This is both shown in the startup logs and in the Web UI. This should inform users of the features available in the current instance. In practice the dissect filter doesn't change that often.