### PR TITLE
Move the pprof HTTP endpoints to a dedicated port

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,9 +138,19 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
+	pprofMux := http.NewServeMux()
 
-	RegisterDebugHandler(mux)
 	RegisterAppHandlers(mux)
+	RegisterDebugHandler(pprofMux)
+
+	go func() {
+		pprofServer := http.Server{
+			Addr:    "localhost:6060",
+			Handler: pprofMux,
+		}
+		logger.Info("Starting debug server")
+		logger.Error("Error starting pprof server", zap.Error(pprofServer.ListenAndServe()))
+	}()
 
 	server := http.Server{
 		Handler:      http.TimeoutHandler(mux, procTimeout, "Processing your request took too long."),


### PR DESCRIPTION
It is always best to run the pprof debug endpoints in a dedicated mux
accessible only via localhost. This increases the security and if needed
we can use port forward or enable access to the `6060` port when needed.