### PR TITLE
Change paths from absolute to relative

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,76 +24,76 @@
     <link
       rel="apple-touch-icon"
       sizes="57x57"
-      href="/static/images/apple-icon-57x57.png"
+      href="static/images/apple-icon-57x57.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="60x60"
-      href="/static/images/apple-icon-60x60.png"
+      href="static/images/apple-icon-60x60.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="72x72"
-      href="/static/images/apple-icon-72x72.png"
+      href="static/images/apple-icon-72x72.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="76x76"
-      href="/static/images/apple-icon-76x76.png"
+      href="static/images/apple-icon-76x76.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="114x114"
-      href="/static/images/apple-icon-114x114.png"
+      href="static/images/apple-icon-114x114.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="120x120"
-      href="/static/images/apple-icon-120x120.png"
+      href="static/images/apple-icon-120x120.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="144x144"
-      href="/static/images/apple-icon-144x144.png"
+      href="static/images/apple-icon-144x144.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="152x152"
-      href="/static/images/apple-icon-152x152.png"
+      href="static/images/apple-icon-152x152.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/static/images/apple-icon-180x180.png"
+      href="static/images/apple-icon-180x180.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="192x192"
-      href="/static/images/android-icon-192x192.png"
+      href="static/images/android-icon-192x192.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="/static/images/favicon-32x32.png"
+      href="static/images/favicon-32x32.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="96x96"
-      href="/static/images/favicon-96x96.png"
+      href="static/images/favicon-96x96.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="16x16"
-      href="/static/images/favicon-16x16.png"
+      href="static/images/favicon-16x16.png"
     />
-    <link rel="manifest" href="/static/manifest.json" />
+    <link rel="manifest" href="static/manifest.json" />
     <meta name="theme-color" content="#ffffff" />
-    <link href="/static/dist/tailwind.css" rel="stylesheet" />
-    <script defer src="/static/js/main.js"></script>
+    <link href="static/dist/tailwind.css" rel="stylesheet" />
+    <script defer src="static/js/main.js"></script>
   </head>
   <body class="flex flex-col min-h-screen p-4 sm:p-0">
     <header


### PR DESCRIPTION
This change allows to use the container with a reverse proxy in front with custom path.

Lets consider the following nginx reverse-proxy configuration:
````
location /dissect-tester/ {
            proxy_pass http://127.0.0.1:8002/;
        }
````

Without the change, static content is redirected to `servername/static/*` instead of `servername/dissect-tester/static/*`. 
This prevents styles, images and scripts to load properly.

The change makes the webpage use relative path and operate normally.