### PR TITLE
fix: handle escaping text on pasting samples

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.48
+          version: v1.54
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
@@ -55,4 +55,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Test
         run: go test ./...
-

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -7,8 +7,6 @@ document.querySelector("#samples").addEventListener("paste", function(e) {
   let pastedText = (e.clipboardData || window.clipboardData).getData("text");
 
   // Insert the plain text into the contenteditable div
-  // document.execCommand("inserttext", false, pastedText);
-  // document.querySelector("#samples").innerText = pastedText;
   const selection = window.getSelection();
   if (!selection.rangeCount) return;
   selection.deleteFromDocument();
@@ -111,8 +109,15 @@ function selectContentEditableLine(el, pos) {
 
 function clearContentEditableLine(el) {
   // remove all mark elements
-  let lines = el.innerHTML.replace(/<\/?[^>]+>/gi, '').trim();
-  el.innerText = lines;
+  let marks = el.querySelectorAll('mark');
+  marks.forEach((mark) => {
+    let text = mark.innerText;
+    let textNode = document.createTextNode(text);
+
+    console.log({ mark, textNode });
+
+    mark.parentNode.replaceChild(textNode, mark);
+  });
 }
 
 function createSVG() {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,5 +1,21 @@
 const API_URL = window.location.href.split("?")[0] + "api/";
 
+document.querySelector("#samples").addEventListener("paste", function(e) {
+  e.preventDefault(); // Prevent the default paste behavior
+
+  // Get the pasted text as plain text
+  let pastedText = (e.clipboardData || window.clipboardData).getData("text");
+
+  // Insert the plain text into the contenteditable div
+  // document.execCommand("inserttext", false, pastedText);
+  // document.querySelector("#samples").innerText = pastedText;
+  const selection = window.getSelection();
+  if (!selection.rangeCount) return;
+  selection.deleteFromDocument();
+  selection.getRangeAt(0).insertNode(document.createTextNode(pastedText));
+  selection.collapseToEnd();
+});
+
 function testSamples() {
   let pattern = document.querySelector("#pattern").value;
   let samples = document.querySelector("#samples").innerText;
@@ -9,7 +25,7 @@ function testSamples() {
 
   let body = new URLSearchParams();
   body.set("tokenizer", pattern);
-  body.set("str", samples.split('\n').filter(function(line) {return line.length > 0}).join('\n'));
+  body.set("str", samples.split('\n').filter(function(line) { return line.length > 0 }).join('\n'));
 
   fetch(url, {
     method: "POST",
@@ -33,7 +49,7 @@ function testSamples() {
         s = JSON.stringify(s, null, 2)
         let textarea = document.createElement("textarea");
         textarea.className = "bg-gray-200 appearance-none border-2 border-gray-200 rounded py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500 font-mono w-full hover:bg-purple-400 hover:border-purple-400 hover:text-white focus:text-black";
-        textarea.id="right"+pos;
+        textarea.id = "right" + pos;
         textarea.setAttribute("z-index", "20");
         textarea.value = s;
         let rows = (s.match(/\n/g) || '').length + 1;
@@ -42,22 +58,22 @@ function testSamples() {
           document.querySelector("#samples").blur();
           document.querySelector("#samples").classList.remove('py-2')
           selectContentEditableLine(document.querySelector("#samples"), pos);
-          let el = document.getElementById('left'+pos);
+          let el = document.getElementById('left' + pos);
           el.scrollIntoView({
-              block: 'nearest',
-              inline: 'start'
+            block: 'nearest',
+            inline: 'start'
           });
 
           textarea.scrollIntoView({
             block: 'nearest',
             inline: 'start'
           });
-          
+
           const intersectionObserver = new IntersectionObserver((entries) => {
             let [entry] = entries;
             if (entry.isIntersecting) {
               setTimeout(function() {
-                connectDivs("left"+pos, "right"+pos, "rgba(167, 139, 250, 1)", 1);
+                connectDivs("left" + pos, "right" + pos, "rgba(167, 139, 250, 1)", 1);
               }, 100)
             }
           });
@@ -71,7 +87,7 @@ function testSamples() {
           clearContentEditableLine(document.querySelector("#samples"));
           document.getElementById('svg-canvas').innerHTML = "";
         }
-        
+
         resultTextArea.appendChild(textarea);
       })
 
@@ -80,12 +96,12 @@ function testSamples() {
 }
 
 function selectContentEditableLine(el, pos) {
-  lines = el.innerText.split('\n').filter(function(line) {return line.length > 0});
+  lines = el.innerText.split('\n').filter(function(line) { return line.length > 0 });
   // console.log(lines);
   let mark = document.createElement('mark');
-  mark.id="left"+pos;
-  mark.className="block bg-purple-400 p-2 pl-4 rounded text-white py-4 -ml-4";
-  mark.style="z-index:20;";
+  mark.id = "left" + pos;
+  mark.className = "block bg-purple-400 p-2 pl-4 rounded text-white py-4 -ml-4";
+  mark.style = "z-index:20;";
   mark.innerText = lines[pos].trim();
   // console.log(mark.outerHTML);
   lines[pos] = mark.outerHTML;
@@ -102,17 +118,17 @@ function clearContentEditableLine(el) {
 function createSVG() {
   let svg = document.getElementById("svg-canvas");
   if (null == svg) {
-    svg = document.createElementNS("http://www.w3.org/2000/svg", 
-                                   "svg");
+    svg = document.createElementNS("http://www.w3.org/2000/svg",
+      "svg");
     svg.setAttribute('id', 'svg-canvas');
     svg.setAttribute('style', 'position:absolute;top:0px;left:0px');
     svg.setAttribute('width', document.body.clientWidth);
     svg.setAttribute('height', document.body.clientHeight);
     svg.setAttribute('pointer-events', 'none');
     svg.setAttribute("z-index", "10");
-    svg.setAttributeNS("http://www.w3.org/2000/xmlns/", 
-                       "xmlns:xlink", 
-                       "http://www.w3.org/1999/xlink");
+    svg.setAttributeNS("http://www.w3.org/2000/xmlns/",
+      "xmlns:xlink",
+      "http://www.w3.org/1999/xlink");
     document.body.appendChild(svg);
   }
   return svg;
@@ -123,7 +139,7 @@ function drawPoint(x, y, radius, color) {
   let shape = document.createElementNS("http://www.w3.org/2000/svg", "circle");
   shape.setAttributeNS(null, "cx", x);
   shape.setAttributeNS(null, "cy", y);
-  shape.setAttributeNS(null, "r",  radius);
+  shape.setAttributeNS(null, "r", radius);
   shape.setAttributeNS(null, "fill", color);
   svg.appendChild(shape);
 }
@@ -131,7 +147,7 @@ function drawPoint(x, y, radius, color) {
 function connectDivs(leftId, rightId, color, tension) {
   let left = document.getElementById(leftId);
   let right = document.getElementById(rightId);
-	
+
   let leftOff = getOffset(left);
   let x1 = leftOff.left;
   let y1 = leftOff.top;
@@ -150,30 +166,23 @@ function connectDivs(leftId, rightId, color, tension) {
 
 function drawCurvedLine(x1, y1, x2, y2, color, tension) {
   let svg = createSVG();
-  let shape = document.createElementNS("http://www.w3.org/2000/svg", 
-                                       "path");
-  let delta = (x2-x1)*tension;
-  let hx1=x1+delta;
-  let hy1=y1;
-  let hx2=x2-delta;
-  let hy2=y2;
-  let path = "M "  + x1 + " " + y1 + 
-             " C " + hx1 + " " + hy1 
-                   + " "  + hx2 + " " + hy2 
-             + " " + x2 + " " + y2;
+  let shape = document.createElementNS("http://www.w3.org/2000/svg",
+    "path");
+  let delta = (x2 - x1) * tension;
+  let hx1 = x1 + delta;
+  let hy1 = y1;
+  let hx2 = x2 - delta;
+  let hy2 = y2;
+  let path = "M " + x1 + " " + y1 +
+    " C " + hx1 + " " + hy1
+    + " " + hx2 + " " + hy2
+    + " " + x2 + " " + y2;
   shape.setAttributeNS(null, "d", path);
   shape.setAttributeNS(null, "fill", "none");
   shape.setAttributeNS(null, "stroke", color);
   shape.setAttributeNS(null, "stroke-width", 5);
   svg.appendChild(shape);
 }
-
-const editor = document.querySelector('pre')
-editor.addEventListener("paste", function(e) {
-  e.preventDefault();
-  const text = e.clipboardData.getData('text/plain');
-  document.execCommand("insertHTML", false, text);
-});
 
 function getOffset(el) {
   const rect = el.getBoundingClientRect();


### PR DESCRIPTION
This fixes the escaping text happening when pasting some logs that contained `<` or `>` since these were interpreted as valid markup.

* Improve the handling of the paste events in the samples block.
* Avoid modifying the text values when moving the mouse out of the items in the "Results" column.

Fix #43.